### PR TITLE
fix: include background service worker

### DIFF
--- a/src/utils/converter.js
+++ b/src/utils/converter.js
@@ -141,7 +141,7 @@ function buildManifest(meta) {
     description: meta.description || '',
     version: meta.version || '1.0.0',
     action: { default_title: 'Enable Userscript' },
-    background: { scripts: ['background.js'] },
+    background: { scripts: ['background.js'], service_worker: 'background.js' },
     host_permissions: hostPerms,
     permissions,
     optional_permissions: ['userScripts'],


### PR DESCRIPTION
## Summary
- generate manifest with both `background.scripts` and `background.service_worker` for cross-browser support

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aec5d2cdf48333934702b64c6a640d