### PR TITLE
feat: add customization options and icon uploads

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { parseMetadata, createZipFiles } from './utils/converter.js';
 
 export default function App() {
@@ -6,6 +6,30 @@ export default function App() {
   const [error, setError] = useState('');
   const [zipBlob, setZipBlob] = useState(null);
   const [zipName, setZipName] = useState('userscript-extension.zip');
+  const [author, setAuthor] = useState('');
+  const [homepage, setHomepage] = useState('');
+  const [support, setSupport] = useState('');
+  const [descriptionOverride, setDescriptionOverride] = useState('');
+  const [iconData, setIconData] = useState(null);
+
+  useEffect(() => {
+    if (!scriptText) {
+      setAuthor('');
+      setHomepage('');
+      setSupport('');
+      setDescriptionOverride('');
+      return;
+    }
+    try {
+      const meta = parseMetadata(scriptText);
+      setDescriptionOverride(meta.description || '');
+      setAuthor(meta.author || '');
+      setHomepage(meta.homepage || '');
+      setSupport(meta.support || '');
+    } catch {
+      /* ignore parse errors */
+    }
+  }, [scriptText]);
 
   const handleFileUpload = (e) => {
     const file = e.target.files[0];
@@ -14,6 +38,19 @@ export default function App() {
     reader.onload = () => setScriptText(reader.result);
     reader.onerror = () => setError('Failed to read file.');
     reader.readAsText(file);
+  };
+
+  const handleIconUpload = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const arrayBuffer = reader.result;
+      const ext = file.name.split('.').pop().toLowerCase();
+      setIconData({ data: new Uint8Array(arrayBuffer), ext });
+    };
+    reader.onerror = () => setError('Failed to read icon file.');
+    reader.readAsArrayBuffer(file);
   };
 
   const handleConvert = async () => {
@@ -25,7 +62,11 @@ export default function App() {
         throw new Error('Script metadata must include at least one @match or @include pattern, and a @name.');
       }
       setZipName(`${meta.name}-extension.zip`);
-      const zipFile = await createZipFiles(meta, scriptText);
+      if (descriptionOverride) meta.description = descriptionOverride;
+      if (author) meta.author = author;
+      if (homepage) meta.homepage = homepage;
+      if (support) meta.support = support;
+      const zipFile = await createZipFiles(meta, scriptText, iconData);
       setZipBlob(zipFile);
     } catch (e) {
       console.error('Conversion error:', e);
@@ -60,6 +101,56 @@ export default function App() {
         />
         <span className="ml-2 text-sm text-gray-600">Choose a <code>.user.js</code> file</span>
       </label>
+      <label className="block mb-2">
+        <span className="sr-only">Extension description</span>
+        <input
+          type="text"
+          value={descriptionOverride}
+          onChange={(e) => setDescriptionOverride(e.target.value)}
+          className="w-full border border-gray-300 rounded p-2 mb-2"
+          placeholder="Extension Description (optional)"
+        />
+      </label>
+      <label className="block mb-2">
+        <span className="sr-only">Author name/email</span>
+        <input
+          type="text"
+          value={author}
+          onChange={(e) => setAuthor(e.target.value)}
+          className="w-full border border-gray-300 rounded p-2 mb-2"
+          placeholder="Author name/email"
+        />
+      </label>
+      <label className="block mb-2">
+        <span className="sr-only">Homepage URL</span>
+        <input
+          type="url"
+          value={homepage}
+          onChange={(e) => setHomepage(e.target.value)}
+          className="w-full border border-gray-300 rounded p-2 mb-2"
+          placeholder="Homepage URL (optional)"
+        />
+      </label>
+      <label className="block mb-2">
+        <span className="sr-only">Support URL</span>
+        <input
+          type="url"
+          value={support}
+          onChange={(e) => setSupport(e.target.value)}
+          className="w-full border border-gray-300 rounded p-2 mb-2"
+          placeholder="Support URL (optional)"
+        />
+      </label>
+      <label className="block mb-2">
+        <span className="sr-only">Upload extension icon</span>
+        <input
+          type="file"
+          accept=".png,.ico,image/png,image/x-icon"
+          onChange={handleIconUpload}
+          className="file:mr-2 file:py-1 file:px-3 file:border-0 file:text-sm file:bg-gray-200 file:cursor-pointer"
+        />
+        <span className="ml-2 text-sm text-gray-600">Choose extension icon (PNG or ICO)</span>
+      </label>
 
       <button
         onClick={handleConvert}
@@ -83,6 +174,7 @@ export default function App() {
             <li>
               <b>Chrome:</b> <code>chrome://extensions</code> → enable <b>Developer mode</b> → <b>Load unpacked</b> → pick the unzipped folder. Open the extension’s <b>Details</b> and switch on <b>Allow User Scripts</b> (or enable the <code>#enable-extension-content-script-user-script</code> flag on older versions). The popup will open.
             </li>
+            <li><b>Tip:</b> If the userscript still doesn't activate, try restarting your browser to refresh permissions.</li>
             <li>
               <b>Firefox:</b> <code>about:debugging</code> → <b>This Firefox</b> → <b>Load Temporary Add-on</b> → select <code>manifest.json</code>. Click <b>Grant permission</b> when asked.
             </li>


### PR DESCRIPTION
## Summary
- allow overriding author, description, and support metadata extracted from userscripts
- permit uploading custom extension icons and bundle a permission-granting options page
- prompt for userScripts permission on install with a friendly heart badge
- clarify compiler attribution with a heavy black heart signature
- switch signature wording to "Made with ❤" across generated files
- autofill description, author, homepage, and support fields from uploaded scripts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0283437dc833380f5203d92af523b