### PR TITLE
Add PayPal donation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ After these steps the userscript is registered and runs on matching pages using 
 
 Have suggestions or found a bug? Please visit feel free to open issues or provide feedback.
 
+If you'd like to support the project, consider donating via [PayPal](https://www.paypal.com/paypalme/my/profile).
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -212,6 +212,18 @@ export default function App() {
         </a>
         .
       </p>
+      <p className="mt-2 text-center text-sm text-gray-600">
+        If you find this tool helpful, you can{' '}
+        <a
+          href="https://www.paypal.com/paypalme/my/profile"
+          className="text-blue-600 hover:underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          support it on PayPal
+        </a>
+        .
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add PayPal donation link in README for supporters
- Include PayPal support link in the app footer

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b2d352e54c8333846e3fca23702d6b