### PR TITLE
Use options_ui for extension options page

### DIFF
--- a/src/utils/converter.js
+++ b/src/utils/converter.js
@@ -166,7 +166,7 @@ function buildManifest(meta) {
     host_permissions: hostPerms,
     permissions,
     optional_permissions: ['userScripts'],
-    options_page: 'options.html',
+    options_ui: { page: 'options.html', open_in_tab: true },
     browser_specific_settings: meta.uuid ? { gecko: { id: meta.uuid } } : undefined,
     minimum_chrome_version: '120'
   };


### PR DESCRIPTION
## Summary
- expose permission request by switching manifest generation to `options_ui`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5ce32c3988333a1c2b8031a21d5b4