### PR TITLE
Remove permission prompt and heart badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Pushes to `main` trigger the GitHub Actions workflow in `.github/workflows/deplo
 
 1. Build or convert a userscript through the web UI to obtain a ZIP archive.
 2. Extract the ZIP and load it as an unpacked extension.
-   - **Chrome:** visit `chrome://extensions`, enable **Developer mode**, choose **Load unpacked**, and select the extracted folder. Open the extension’s **Details** page and enable **Allow User Scripts** (or enable the `#enable-extension-content-script-user-script` flag on older versions). Click the toolbar icon once to grant the `userScripts` permission.
+   - **Chrome:** visit `chrome://extensions`, enable **Developer mode**, choose **Load unpacked**, and select the extracted folder. Open the extension’s **Details** page and enable **Allow User Scripts** (or enable the `#enable-extension-content-script-user-script` flag on older versions).
    - **Firefox:** open `about:debugging`, choose **This Firefox**, click **Load Temporary Add-on**, and select `manifest.json`. Grant the requested permission when prompted.
 
 After these steps the userscript is registered and runs on matching pages using each browser’s native user‑script engine.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -195,12 +195,12 @@ export default function App() {
           <div className="mt-4 bg-yellow-50 border-l-4 border-yellow-300 p-3 rounded flex items-start">
             <span className="mr-2 text-yellow-600 text-lg" aria-hidden="true">⚠️</span>
             <div>
-              <b>Note:</b> After loading the extension, <b>click the extension’s toolbar icon once</b> to grant <code>userScripts</code> permission and register the userscript.
-              <div className="text-gray-700 mt-1">This step is required for the userscript to activate.</div>
+                <b>Note:</b> After loading the extension, open the extension’s <b>Details</b> page in your browser and enable the <code>userScripts</code> permission to register the userscript.
+                <div className="text-gray-700 mt-1">This step is required for the userscript to activate.</div>
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
 
       <p className="mt-8 text-center text-sm text-gray-600">
         Feedback, suggestions, or issues? Visit the{' '}

--- a/src/utils/converter.js
+++ b/src/utils/converter.js
@@ -155,7 +155,7 @@ function buildManifest(meta) {
     name: meta.name || 'Converted Userscript',
     description:
       (meta.description || '') +
-      ' — Made with ❤ using UserScript-Compiler by Henry Russell',
+      ' — Made using UserScript-Compiler by Henry Russell',
     version: meta.version || '1.0.0',
     author: meta.author || undefined,
     homepage_url: meta.homepage || undefined,
@@ -177,7 +177,7 @@ function generateBackgroundScriptCode(meta) {
   const prefix = `userscript_${sanitizedName}_`;
   const scriptId = `us_${sanitizedName || 'script'}`;
 
-  return `/* Made with ❤ using UserScript-Compiler by Henry Russell: https://hrussellzfac023.github.io/UserScript-Compiler/ */(() => {
+  return `/* Made using UserScript-Compiler by Henry Russell: https://hrussellzfac023.github.io/UserScript-Compiler/ */(() => {
   const browser = globalThis.browser || globalThis.chrome;
   function hasUserScriptsPermission() {
     return new Promise((resolve) => {
@@ -190,23 +190,6 @@ function generateBackgroundScriptCode(meta) {
             .then(resolve, () => resolve(false));
         }
       } catch {
-        resolve(false);
-      }
-    });
-  }
-
-  function requestUserScriptsPermission() {
-    return new Promise((resolve) => {
-      try {
-        if (browser.permissions.request.length > 1) {
-          browser.permissions.request({ permissions: ['userScripts'] }, resolve);
-        } else {
-          browser.permissions
-            .request({ permissions: ['userScripts'] })
-            .then(resolve, () => resolve(false));
-        }
-      } catch (e) {
-        console.error('Permission request error:', e);
         resolve(false);
       }
     });
@@ -346,30 +329,20 @@ function generateBackgroundScriptCode(meta) {
     }
     browser.runtime.onMessage.addListener(handleMessage);
   }
-  async function updateBadgeAndRegister() {
+  async function updateRegistration() {
     try {
       const has = await hasUserScriptsPermission();
       if (has) {
         await registerIfPossible();
-        browser.action?.setBadgeText({ text: '' });
-      } else {
-        browser.action?.setBadgeText({ text: '❤' });
-        browser.action?.setBadgeBackgroundColor?.({ color: '#e0245e' });
       }
     } catch (e) {
       console.warn('Permission check error:', e);
     }
   }
-  updateBadgeAndRegister();
+  updateRegistration();
   if (browser.runtime?.onInstalled) {
     browser.runtime.onInstalled.addListener(() => {
       browser.runtime.openOptionsPage?.();
-    });
-  }
-  if (browser.action?.onClicked) {
-    browser.action.onClicked.addListener(async () => {
-      const granted = await requestUserScriptsPermission();
-      if (granted) await updateBadgeAndRegister();
     });
   }
 })();`;
@@ -609,32 +582,10 @@ export async function createZipFiles(meta, scriptText, iconData) {
   const optionsHtml = `<!DOCTYPE html>
 <html><head><meta charset="UTF-8"><title>Extension Options</title></head><body style="font-family:sans-serif;padding:20px;text-align:center;background:#f9fafb;">
   <h2>Setup Extension</h2>
-  <p>Click the button below to grant the <code>userScripts</code> permission:</p>
-  <button id="grant" style="padding:8px 16px;font-size:16px;">Grant Permissions</button>
-  <p id="status"></p>
-  <p style="margin-top:20px;font-size:12px;color:#555;">Made with ❤ using UserScript-Compiler by Henry Russell</p>
-  <script>
-    const browser = window.browser || window.chrome;
-    document.getElementById('grant').onclick = () => {
-      try {
-        if (browser.permissions.request.length > 1) {
-          browser.permissions.request({ permissions: ['userScripts'] }, (granted) => {
-            document.getElementById('status').textContent = granted ? 'Permission granted!' : 'Permission not granted.';
-          });
-        } else {
-          browser.permissions.request({ permissions: ['userScripts'] }).then((granted) => {
-            document.getElementById('status').textContent = granted ? 'Permission granted!' : 'Permission not granted.';
-          }, () => {
-            document.getElementById('status').textContent = 'Permission not granted.';
-          });
-        }
-      } catch (e) {
-        console.error(e);
-      }
-    };
-  </script>
+  <p>To enable the <code>userScripts</code> permission, open the extension's details in your browser and allow it manually.</p>
+  <p style="margin-top:20px;font-size:12px;color:#555;">Made using UserScript-Compiler by Henry Russell</p>
 </body></html>`;
-zip.file('options.html', optionsHtml);
+  zip.file('options.html', optionsHtml);
   const content = await zip.generateAsync({ type: 'blob' });
   return content;
 }


### PR DESCRIPTION
## Summary
- Remove non-functional permissions request and badge from generated extensions
- Replace permission button with instructions to enable `userScripts` manually
- Update docs and UI to describe manual permission setup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5df5c6e5c8333992b30028d361bc7