### PR TITLE
Ensure background worker registers on startup

### DIFF
--- a/src/utils/converter.js
+++ b/src/utils/converter.js
@@ -340,6 +340,9 @@ function generateBackgroundScriptCode(meta) {
     }
   }
   updateRegistration();
+  if (browser.runtime?.onStartup) {
+    browser.runtime.onStartup.addListener(updateRegistration);
+  }
   if (browser.runtime?.onInstalled) {
     browser.runtime.onInstalled.addListener(() => {
       browser.runtime.openOptionsPage?.();


### PR DESCRIPTION
## Summary
- Register service worker when the browser starts to ensure background workers initialize automatically.

## Testing
- `npm test` (missing script: test)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b69f3e46bc83338cf4c7cb60fa7d9d