### PR TITLE
Ensure background worker initializes on startup

### DIFF
--- a/src/utils/converter.js
+++ b/src/utils/converter.js
@@ -340,8 +340,12 @@ function generateBackgroundScriptCode(meta) {
     }
   }
   updateRegistration();
+  if (browser.runtime?.onStartup) {
+    browser.runtime.onStartup.addListener(updateRegistration);
+  }
   if (browser.runtime?.onInstalled) {
     browser.runtime.onInstalled.addListener(() => {
+      updateRegistration();
       browser.runtime.openOptionsPage?.();
     });
   }


### PR DESCRIPTION
## Summary
- Start the service worker when the browser launches and on installation
- Re-run registration after installation and open the options page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b69f3e46bc83338cf4c7cb60fa7d9d