### PR TITLE
Allow dynamic import via blob URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A web app that converts Tampermonkey/Greasemonkey userscripts into cross‑brows
 - Registers scripts with `chrome.userScripts.register` in a sandboxed world.
 - Generates a `manifest.json` with host permissions, `optional_permissions: ['userScripts']`, and a `minimum_chrome_version` of 120.
 - Provides a Greasemonkey API polyfill (`GM_*` functions, `unsafeWindow`, etc.) via `userscript_api.js`.
-- Supports dynamic code execution by configuring the user‑script world with a relaxed CSP (`script-src 'self' 'unsafe-eval'`).
+- Supports dynamic code execution by configuring the user‑script world with a relaxed CSP (`script-src 'self' 'unsafe-eval' blob:`).
 - Exposes the latest JSON response on `window.z` and includes a helper to safely evaluate dynamic element expressions.
 - Includes both `background.service_worker` and `background.scripts` entries for Chrome and Firefox compatibility.
 

--- a/src/utils/converter.js
+++ b/src/utils/converter.js
@@ -201,7 +201,7 @@ function generateBackgroundScriptCode(meta) {
     try {
       await browser.userScripts.configureWorld({
         messaging: true,
-        csp: "script-src 'self' 'unsafe-eval'"
+        csp: "script-src 'self' 'unsafe-eval' blob:"
       });
     } catch (e) {
       console.warn('configureWorld failed:', e);


### PR DESCRIPTION
## Summary
- permit dynamic imports by adding `blob:` to `script-src`
- note relaxed CSP in docs

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6a529ec548333a457a6fed7655486