### PR TITLE
Handle Firefox permission reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Pushes to `main` trigger the GitHub Actions workflow in `.github/workflows/deplo
 1. Build or convert a userscript through the web UI to obtain a ZIP archive.
 2. Extract the ZIP and load it as an unpacked extension.
    - **Chrome:** visit `chrome://extensions`, enable **Developer mode**, choose **Load unpacked**, and select the extracted folder. Open the extension’s **Details** page and enable **Allow User Scripts** (or enable the `#enable-extension-content-script-user-script` flag on older versions).
-   - **Firefox:** open `about:debugging`, choose **This Firefox**, click **Load Temporary Add-on**, and select `manifest.json`. Grant the requested permission when prompted.
+   - **Firefox:** open `about:debugging`, choose **This Firefox**, click **Load Temporary Add-on**, and select `manifest.json`. Grant the requested permission when prompted. If you enable the permission later from the add-on's details page, the extension will now detect the change and register automatically without requiring a manual reload.
 
 After these steps the userscript is registered and runs on matching pages using each browser’s native user‑script engine.
 

--- a/src/utils/converter.js
+++ b/src/utils/converter.js
@@ -349,6 +349,13 @@ function generateBackgroundScriptCode(meta) {
       browser.runtime.openOptionsPage?.();
     });
   }
+  if (browser.permissions?.onAdded) {
+    browser.permissions.onAdded.addListener((perms) => {
+      if (perms.permissions?.includes('userScripts')) {
+        updateRegistration();
+      }
+    });
+  }
 })();`;
 }
 


### PR DESCRIPTION
## Summary
- Reload user script registration automatically when userScripts permission is granted
- Note Firefox auto-registration in docs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6af2f33a08333964bef8a28bc5654